### PR TITLE
Fix/sorting trans

### DIFF
--- a/app/components/SendTransactions/AddressBook.js
+++ b/app/components/SendTransactions/AddressBook.js
@@ -147,7 +147,8 @@ class AddressBook extends Component {
             return (
               <div className= {index % 2 !== 0 ? rowClassName : rowClassName + " tableRowEven"} onClick={this.rowClicked.bind(this, friend)} onMouseLeave={this.handleMouseLeave} onMouseEnter={this.handleMouseEnter.bind(this, friend)} style={{cursor: this.props.sendPanel ? "pointer" : "default"}} key={`friend_${index}`}>
                 <div className={this.props.sendPanel ? "col-sm-4 tableColumn tableColumContactFix" : "col-sm-4 tableColumn tableColumContactFix selectableText"}>
-                  {friend.ansrecord != null ? renderHTML(`${friend.ansrecord.name}<span className="Receive__ans-code">#${friend.ansrecord.code}</span>`) : friend.name}
+                  {friend.ansrecord != null ? <img src={ansAddresImage} style={{padding:"0 5px 3px 0"}}></img> : null}
+                  {friend.ansrecord != null ? renderHTML(`${friend.ansrecord.name}<span className="Receive__ans-code">#${friend.ansrecord.code} </span> `) : friend.name}
                 </div>
                 <div className={this.props.sendPanel ? "col-sm-7 tableColumn" : "col-sm-7 tableColumn selectableText"}>
                   {friend.address.address}

--- a/app/components/SendTransactions/AddressBook.js
+++ b/app/components/SendTransactions/AddressBook.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import {TweenMax} from "gsap";
 import { connect } from 'react-redux';
-
+import renderHTML from 'react-render-html';
 import low from '../../utils/low';
 import * as actions from '../../actions';
 
 import $ from 'jquery';
-
+const ansAddresImage = require('../../../resources/images/ans_address.png');
 const Tools = require('../../utils/tools');
 const { clipboard } = require('electron');
 import { getContacts, deleteContact } from "../../Managers/SQLManager";
@@ -30,6 +30,18 @@ class AddressBook extends Component {
       this.updateTable(this.props.friends);
     });
 
+  }
+
+  getAddressDiplay(address) {
+    if (address.ans) {
+      return (
+        <div>
+          <img src={ansAddresImage} />
+        </div>
+      )
+    } else {
+      return null;
+    }
   }
 
   updateTable(friendList){
@@ -135,7 +147,7 @@ class AddressBook extends Component {
             return (
               <div className= {index % 2 !== 0 ? rowClassName : rowClassName + " tableRowEven"} onClick={this.rowClicked.bind(this, friend)} onMouseLeave={this.handleMouseLeave} onMouseEnter={this.handleMouseEnter.bind(this, friend)} style={{cursor: this.props.sendPanel ? "pointer" : "default"}} key={`friend_${index}`}>
                 <div className={this.props.sendPanel ? "col-sm-4 tableColumn tableColumContactFix" : "col-sm-4 tableColumn tableColumContactFix selectableText"}>
-                  {friend.ansrecord != null ? friend.ansrecord.name + '#' + friend.ansrecord.code: friend.name}
+                  {friend.ansrecord != null ? renderHTML(`${friend.ansrecord.name}<span className="Receive__ans-code">#${friend.ansrecord.code}</span>`) : friend.name}
                 </div>
                 <div className={this.props.sendPanel ? "col-sm-7 tableColumn" : "col-sm-7 tableColumn selectableText"}>
                   {friend.address.address}

--- a/app/components/Transactions/Transaction.js
+++ b/app/components/Transactions/Transaction.js
@@ -304,7 +304,6 @@ class Transaction extends Component {
                     </div>
                    </div>
                     <div id={`trans_bottom_${index}`} onClick={this.rowClickedFixMisSlideUp} className="row extraInfoTransaction" style={{ paddingLeft: "2%", width: "100%", paddingTop: "6px", paddingBottom: "6px", cursor:"default", zIndex:"2", display:"none"}}>
-                     
                           <div className="col-sm-4">
                             <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2 small-header">{lang.dateString}</span></p>
                             <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3 small-text">{(new Date(t.time).toDateString()).toString()}</span></p>

--- a/app/components/Transactions/Transaction.js
+++ b/app/components/Transactions/Transaction.js
@@ -308,22 +308,25 @@ class Transaction extends Component {
                       <p style={{ margin: '0px', fontSize: "12px" }}>{this.renderStatus(t.confirmations)}</p>
                     </div>
                     <div id={`trans_bottom_${index}`} onClick={this.rowClickedFixMisSlideUp} className="row extraInfoTransaction" style={{ paddingLeft: "4%", width: "100%", paddingTop: "11px", paddingBottom: "11px", cursor:"default", zIndex:"2", display:"none"}}>
-                      <div className="col-sm-8">
-                        <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2">{lang.dateString}</span></p>
-                        <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3">{(new Date(t.time).toDateString()).toString()}</span></p>
-                      </div>
-                      <div className="col-sm-4">
-                        <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2">{lang.confirmations}</span></p>
-                        <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3">{t.confirmations}</span></p>
-                      </div>
-                      <div className="col-sm-8">
-                        <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2">{lang.transactionId}</span></p>
-                        <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3 transactionId selectableText">{t.transaction_id}</span></p>
-                      </div>
-                      <div className="col-sm-4">
-                        <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2">{lang.transactionFee}</span></p>
-                        <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3">{t.fee}</span></p>
-                      </div>
+                        <div className="col-sm-8" style={{display:"flex",justifyContent:"flex-start"}}>
+                          <div className="col-sm-3">
+                            <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2">{lang.dateString}</span></p>
+                            <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3">{(new Date(t.time).toDateString()).toString()}</span></p>
+                          </div>
+                          <div className="col-sm-2">
+                            <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2">{lang.confirmations}</span></p>
+                            <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3">{t.confirmations}</span></p>
+                          </div>
+                          <div className="col-sm-2">
+                            <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2">{lang.transactionFee}</span></p>
+                            <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3">{t.fee}</span></p>
+                          </div>
+                          </div>
+                          <div className="col-sm-8">
+                            <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2">{lang.transactionId}</span></p>
+                            <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3 transactionId selectableText">{t.transaction_id}</span></p>
+                         
+                        </div>
                     </div>
                   </div>
                 );

--- a/app/components/Transactions/Transaction.js
+++ b/app/components/Transactions/Transaction.js
@@ -287,6 +287,7 @@ class Transaction extends Component {
                 }
 
                 return (
+                <div> 
                   <div className= {counter % 2 !== 0 ? rowClassName : rowClassName + " tableRowEven"} style={{padding:"0",cursor: "pointer", fontSize: "15px", justifyContent:"space-around"}} key={`transaction_${index}_${t.txid}`} onClick={this.rowClicked.bind(this, index)}>
                     <div className="col-sm-3" style={{}}>
                       <p style={{ margin: '0px' }}><span>{moment(t.time).format('MMMM Do')}</span></p>
@@ -301,8 +302,9 @@ class Transaction extends Component {
                       <p style={{ margin: '0px' }}>{t.amount} ECC</p>
                       <p style={{ margin: '0px', fontSize: "12px" }}>{this.renderStatus(t.confirmations)}</p>
                     </div>
+                   </div>
                     <div id={`trans_bottom_${index}`} onClick={this.rowClickedFixMisSlideUp} className="row extraInfoTransaction" style={{ paddingLeft: "2%", width: "100%", paddingTop: "6px", paddingBottom: "6px", cursor:"default", zIndex:"2", display:"none"}}>
-                        <div className="col-sm-8" style={{display:"flex",justifyContent:"flex-start", padding:"0", maxWidth:"725px"}}>
+                     
                           <div className="col-sm-4">
                             <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2 small-header">{lang.dateString}</span></p>
                             <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3 small-text">{(new Date(t.time).toDateString()).toString()}</span></p>
@@ -315,17 +317,13 @@ class Transaction extends Component {
                             <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2 small-header">{lang.transactionFee}</span></p>
                             <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3 small-text">{t.fee}</span></p>
                           </div>
-                        </div>
+                     
                         <div className="col-sm-8">
                             <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2 small-header">{lang.transactionId}</span></p>
                             <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3 small-text selectableText">{t.transaction_id}</span></p>
                         </div>
-                        <div className="col-sm-8">
-                            <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2 small-header">Memo</span></p>
-                            <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3 small-text selectableText">Paying this dude for some bullshit I know he'll never send</span></p>
-                        </div>
                     </div>
-                  </div>
+                </div>
                 );
               }
               return null;

--- a/app/components/Transactions/Transaction.js
+++ b/app/components/Transactions/Transaction.js
@@ -307,25 +307,28 @@ class Transaction extends Component {
                       <p style={{ margin: '0px' }}>{t.amount} ECC</p>
                       <p style={{ margin: '0px', fontSize: "12px" }}>{this.renderStatus(t.confirmations)}</p>
                     </div>
-                    <div id={`trans_bottom_${index}`} onClick={this.rowClickedFixMisSlideUp} className="row extraInfoTransaction" style={{ paddingLeft: "4%", width: "100%", paddingTop: "11px", paddingBottom: "11px", cursor:"default", zIndex:"2", display:"none"}}>
-                        <div className="col-sm-8" style={{display:"flex",justifyContent:"flex-start"}}>
+                    <div id={`trans_bottom_${index}`} onClick={this.rowClickedFixMisSlideUp} className="row extraInfoTransaction" style={{ paddingLeft: "2%", width: "100%", paddingTop: "6px", paddingBottom: "6px", cursor:"default", zIndex:"2", display:"none"}}>
+                        <div className="col-sm-8" style={{display:"flex",justifyContent:"flex-start", padding:"0", maxWidth:"725px"}}>
+                          <div className="col-sm-4">
+                            <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2 small-header">{lang.dateString}</span></p>
+                            <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3 small-text">{(new Date(t.time).toDateString()).toString()}</span></p>
+                          </div>
                           <div className="col-sm-3">
-                            <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2">{lang.dateString}</span></p>
-                            <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3">{(new Date(t.time).toDateString()).toString()}</span></p>
+                            <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2 small-header">{lang.confirmations}</span></p>
+                            <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3 small-text">{t.confirmations}</span></p>
                           </div>
-                          <div className="col-sm-2">
-                            <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2">{lang.confirmations}</span></p>
-                            <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3">{t.confirmations}</span></p>
+                          <div className="col-sm-3">
+                            <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2 small-header">{lang.transactionFee}</span></p>
+                            <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3 small-text">{t.fee}</span></p>
                           </div>
-                          <div className="col-sm-2">
-                            <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2">{lang.transactionFee}</span></p>
-                            <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3">{t.fee}</span></p>
-                          </div>
-                          </div>
-                          <div className="col-sm-8">
-                            <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2">{lang.transactionId}</span></p>
-                            <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3 transactionId selectableText">{t.transaction_id}</span></p>
-                         
+                        </div>
+                        <div className="col-sm-8">
+                            <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2 small-header">{lang.transactionId}</span></p>
+                            <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3 small-text selectableText">{t.transaction_id}</span></p>
+                        </div>
+                        <div className="col-sm-8">
+                            <p className="transactionInfoTitle" style={{ margin: '5px 0px 0px 0px' }}><span className="desc2 small-header">Memo</span></p>
+                            <p style={{ margin: '0px 0px 5px 0px' }}><span className="desc3 small-text selectableText">Paying this dude for some bullshit I know he'll never send</span></p>
                         </div>
                     </div>
                   </div>

--- a/app/dist/style.css
+++ b/app/dist/style.css
@@ -15284,8 +15284,8 @@ li.active.have-children span::after {
   margin-top: 30px; }
 
 .Receive__ans-code {
-  font-size: 12px;
-  font-weight: bold;
+ /* font-size: 12px;
+  font-weight: bold;*/
   color: #2e2e3a; }
 
 .Receive__upgrade-text {

--- a/app/styles/Receive.scss
+++ b/app/styles/Receive.scss
@@ -141,9 +141,12 @@
 }
 
 .Receive__ans-code{
-	font-size: 12px;
+	/*font-size: 12px;
     font-weight: bold;
-    color: #2e2e3a;
+    color: #2e2e3a;*/
+    @include themify($themes) {
+		color: themed('tableRowHeaderColor');
+	}
 }
 
 .Receive__upgrade-text{

--- a/app/styles/Table.scss
+++ b/app/styles/Table.scss
@@ -61,6 +61,18 @@
   box-shadow: 0 2px 4px -3px rgba(0, 0, 0, 0.74);
 }
 
+.tableRowCustom:hover{
+ @include themify($themes) { 
+    background-color: themed('tableHoverColor');
+  }
+}
+
+.tableRowCustom:active{
+ @include themify($themes) { 
+    background-color: themed('tableActiveColor');
+  }
+}
+
 .tableRowCustomTransactions{
   height: auto;
   align-items: center;
@@ -109,12 +121,16 @@
 }
 
 .extraInfoTransaction{
-
   @include themify($themes) { 
     /*background-color: themed('bodyBackgroundColor'); */
     background-color: themed('tableExtraBackgroundColor'); 
   }
-  
+}
+
+.extraInfoTransaction:hover{
+  @include themify($themes) { 
+    /*background-color: themed('tableBackgroundColor');*/
+  }
 }
 
 .tableRowSelected{

--- a/app/styles/Transactions.scss
+++ b/app/styles/Transactions.scss
@@ -144,6 +144,16 @@ i.fa.fa-chevron-down{
     }
 }
 
+.small-text {
+   font-size: 13px;
+   font-weight: 400;
+}
+
+.small-header {
+   font-size: 13px;
+   font-weight: 600;
+}
+
 .container-1{
   width: 300px;
   vertical-align: middle;

--- a/app/styles/themes.scss
+++ b/app/styles/themes.scss
@@ -22,7 +22,7 @@ $themes: (
     //tableRowColor: #acb0bd,
     tableRowHeaderColor: #555d77,
     tableExtraBackgroundColor: #181e35,
-    tableHoverColor: #272a33,
+    tableHoverColor: #1b223d,
     tableActiveColor: #181e35,
 
     //HOME PANEL
@@ -98,7 +98,8 @@ $themes: (
     popupMessageText: #d09128,
     eccTicker: #d09128,
     mainElementBoxShadow: 0 4px 11px -6px black,
-
+    
+    
     bigPanelTimeColor: #252d4f,
     manchaBackgroundColor: rgba(0,0,0,0.7),
 

--- a/app/styles/themes.scss
+++ b/app/styles/themes.scss
@@ -22,6 +22,8 @@ $themes: (
     //tableRowColor: #acb0bd,
     tableRowHeaderColor: #555d77,
     tableExtraBackgroundColor: #181e35,
+    tableHoverColor: #272a33,
+    tableActiveColor: #181e35,
 
     //HOME PANEL
     homePanelsBackgroundColor: #1c2340,
@@ -154,6 +156,8 @@ $themes: (
     tableRowColor: #bfbfbf,
     tableRowHeaderColor: #464b5a,
     tableExtraBackgroundColor: #1c1c23,
+    tableHoverColor: #272a33,
+    tableActiveColor:#1c1c23,
 
     //HOME PANEL
     homePanelsBackgroundColor: #22252d,


### PR DESCRIPTION
Added back in split styling for ANS names and code that follows, added back in ANS icon for ANS addresses appearing in various spots.  Hover and down states added for tables which should make things a bit nicer but might need to be looked at for places where the whole bar is not the link like when deleting or editing a contact in the contact pane.  Some restyling of the transaction extra info which is take it or leave it at the moment, was pushing things left to leave room for right side actions or extra goodies.